### PR TITLE
Add basic pages for logged-in navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,10 @@ import React, { useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import About from './pages/About';
+import Dashboard from './pages/Dashboard';
+import Calendar from './pages/Calendar';
+import Tasks from './pages/Tasks';
+import UploadDocuments from './pages/UploadDocuments';
 import Navbar from './components/Navbar';
 import Login from './components/Login';
 
@@ -13,9 +17,11 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/about" element={<About />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/calendar" element={<Calendar />} />
+        <Route path="/tasks" element={<Tasks />} />
+        <Route path="/upload-documents" element={<UploadDocuments />} />
         <Route path="/login" element={<Login />} />
-
-
       </Routes>
     </>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -33,9 +33,10 @@ function Navbar({ loggedIn }) {
             <li><Link to="/about">A Propos</Link></li>
             {loggedIn && (
               <>
-                <li><a href="#features">Fonctionnalités</a></li>
+                <li><Link to="/dashboard">Tableau de Bord</Link></li>
                 <li><Link to="/calendar">Calendrier</Link></li>
-                <li><a href="#dashboard">Tableau de Bord</a></li>
+                <li><Link to="/tasks">Tâches</Link></li>
+                <li><Link to="/upload-documents">Documents</Link></li>
               </>
             )}
             <li><a href="#contact">Assistance</a></li>

--- a/src/pages/Calendar.jsx
+++ b/src/pages/Calendar.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Calendar() {
+  return (
+    <div>
+      <h2>Calendar</h2>
+      <p>Placeholder for calendar content.</p>
+    </div>
+  );
+}
+
+export default Calendar;

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Dashboard() {
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <p>Placeholder for dashboard content.</p>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Tasks() {
+  return (
+    <div>
+      <h2>Tasks</h2>
+      <p>Placeholder for tasks content.</p>
+    </div>
+  );
+}
+
+export default Tasks;

--- a/src/pages/UploadDocuments.jsx
+++ b/src/pages/UploadDocuments.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function UploadDocuments() {
+  return (
+    <div>
+      <h2>Upload Documents</h2>
+      <p>Placeholder for document upload content.</p>
+    </div>
+  );
+}
+
+export default UploadDocuments;


### PR DESCRIPTION
## Summary
- create placeholder pages for Dashboard, Calendar, Tasks and Upload Documents
- wire routes to the new pages
- update navbar links when logged in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68651c8e55ac8332875242d895f92e54